### PR TITLE
Flatten Event templates

### DIFF
--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -24,6 +24,6 @@ def uk_pilot_event_templates_repositories():
     wfa_repo_archive(
         name = "wfa_measurement_proto",
         repo = "cross-media-measurement-api",
-        sha256 = "69ee69cbfa11ba90ca172d3141a9465a4408883e1aa559d56ef740bd01d474ff",
-        version = "0.23.0",
+        sha256 = "3ccf5e4e81f2b0cd9abfc0fe9945096e6ff1c18577a9d9f67ea60470c64c3ec3",
+        version = "0.39.1",
     )

--- a/src/main/proto/eventtemplates/display_template.proto
+++ b/src/main/proto/eventtemplates/display_template.proto
@@ -30,12 +30,21 @@ message Display {
 
   // More than 0% of the ad was displayed in the browser for more than
   // 0 seconds.
-  bool viewable_0_percent_plus = 1;
+  bool viewable_0_percent_plus = 1
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 0%+"
+      }];
   // More than 50% of the ad was displayed in the browser for at least
   // 1 continuous second.
   // AKA MRC Viewability standard
-  bool viewable_50_percent_plus = 2;
+  bool viewable_50_percent_plus = 2
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 50%+"
+      }];
   // 100% of the ad was displayed in the browser for at least
   // 1 continous second.
-  bool viewable_100_percent = 3;
+  bool viewable_100_percent = 3
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 100%+"
+      }];
 }

--- a/src/main/proto/eventtemplates/display_template.proto
+++ b/src/main/proto/eventtemplates/display_template.proto
@@ -23,7 +23,7 @@ option java_multiple_files = true;
 
 message Display {
   option (.wfa.measurement.api.v2alpha.event_template) = {
-    name: "Display"
+    name: "display"
     display_name: "Display Ad"
     description: "An Event Template for display ad events."
   };

--- a/src/main/proto/eventtemplates/display_template.proto
+++ b/src/main/proto/eventtemplates/display_template.proto
@@ -28,17 +28,14 @@ message Display {
     description: "An Event Template for display ad events."
   };
 
-  message Viewability {
-    // More than 0% of the ad was displayed in the browser for more than
-    // 0 seconds.
-    bool viewable_0_percent_plus = 1;
-    // More than 50% of the ad was displayed in the browser for at least
-    // 1 continuous second.
-    // AKA MRC Viewability standard
-    bool viewable_50_percent_plus = 2;
-    // 100% of the ad was displayed in the browser for at least
-    // 1 continous second.
-    bool viewable_100_percent = 3;
-  }
-  Viewability viewability = 1;
+  // More than 0% of the ad was displayed in the browser for more than
+  // 0 seconds.
+  bool viewable_0_percent_plus = 1;
+  // More than 50% of the ad was displayed in the browser for at least
+  // 1 continuous second.
+  // AKA MRC Viewability standard
+  bool viewable_50_percent_plus = 2;
+  // 100% of the ad was displayed in the browser for at least
+  // 1 continous second.
+  bool viewable_100_percent = 3;
 }

--- a/src/main/proto/eventtemplates/video_template.proto
+++ b/src/main/proto/eventtemplates/video_template.proto
@@ -28,28 +28,25 @@ message Video {
     description: "An Event Template for video ad events."
   };
 
-  // Measures the percentage of a video ad that was viewed.
-  message DigitalVideoCompletionStatus {
-    bool completed_0_percent_plus = 1;
-    bool completed_25_percent_plus = 2;
-    bool completed_50_percent_plus = 3;
-    bool completed_75_percent_plus = 4;
-    bool completed_100_percent = 5;
-  }
+  // These field measure the percentage of a video ad that was viewed.
+  // Should be set cumulatively. e.g. if the completed_50_percent_plus is true
+  // then it's an error if the completed_25_percent_plus and
+  // completed_0_percent_plus fields are not also true
+  bool completed_0_percent_plus = 1;
+  bool completed_25_percent_plus = 2;
+  bool completed_50_percent_plus = 3;
+  bool completed_75_percent_plus = 4;
+  bool completed_100_percent = 5;
 
-  message Viewability {
-    // More than 0% of the ad was displayed in the browser for more than
-    // 0 seconds.
-    bool viewable_0_percent_plus = 1;
-    // More than 50% of the ad was displayed in the browser for at least
-    // 2 continuous seconds.
-    // AKA Old MRC Viewability standard
-    bool viewable_50_percent_plus = 2;
-    // 100% of the ad was displayed in the browser for at least
-    // 2 continuous seconds.
-    // AKA New MRC Viewability standard
-    bool viewable_100_percent = 3;
-  }
-  Viewability viewability = 1;
-  DigitalVideoCompletionStatus digital_video_completion_status = 2;
+  // More than 0% of the ad was displayed in the browser for more than
+  // 0 seconds.
+  bool viewable_0_percent_plus = 6;
+  // More than 50% of the ad was displayed in the browser for at least
+  // 2 continuous seconds.
+  // AKA Old MRC Viewability standard
+  bool viewable_50_percent_plus = 7;
+  // 100% of the ad was displayed in the browser for at least
+  // 2 continuous seconds.
+  // AKA New MRC Viewability standard
+  bool viewable_100_percent = 8;
 }

--- a/src/main/proto/eventtemplates/video_template.proto
+++ b/src/main/proto/eventtemplates/video_template.proto
@@ -28,7 +28,6 @@ message Video {
     description: "An Event Template for video ad events."
   };
 
-  // These field measure the percentage of a video ad that was viewed.
   // This video ad was viewed 0 percent.
   bool completed_0_percent_plus = 1;
   // This video ad was viewed more than 25 percent. If this is true, then

--- a/src/main/proto/eventtemplates/video_template.proto
+++ b/src/main/proto/eventtemplates/video_template.proto
@@ -29,13 +29,21 @@ message Video {
   };
 
   // These field measure the percentage of a video ad that was viewed.
-  // Should be set cumulatively. e.g. if the completed_50_percent_plus is true
-  // then it's an error if the completed_25_percent_plus and
-  // completed_0_percent_plus fields are not also true
+  // This video ad was viewed 0 percent.
   bool completed_0_percent_plus = 1;
+  // This video ad was viewed more than 25 percent. If this is true, then
+  // completed_0_percent_plus must be true.
   bool completed_25_percent_plus = 2;
+  // This video ad was viewed more than 50 percent. If this is true, then
+  // completed_25_percent_plus and completed_0_percent_plus must be true.
   bool completed_50_percent_plus = 3;
+  // This video ad was viewed more than 75 percent. If this is true, then
+  // completed_50_percent_plus, completed_25_percent_plus and
+  // completed_0_percent_plus must be true.
   bool completed_75_percent_plus = 4;
+  // This video ad was viewed 100 percent. If this is true, then
+  // completed_75_percent_plus, completed_50_percent_plus,
+  // completed_25_percent_plus and completed_0_percent_plus must be true.
   bool completed_100_percent = 5;
 
   // More than 0% of the ad was displayed in the browser for more than

--- a/src/main/proto/eventtemplates/video_template.proto
+++ b/src/main/proto/eventtemplates/video_template.proto
@@ -29,31 +29,55 @@ message Video {
   };
 
   // This video ad was viewed 0 percent.
-  bool completed_0_percent_plus = 1;
+  bool completed_0_percent_plus = 1
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Completed 0%+"
+      }];
   // This video ad was viewed more than 25 percent. If this is true, then
   // completed_0_percent_plus must be true.
-  bool completed_25_percent_plus = 2;
+  bool completed_25_percent_plus = 2
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Completed 25%+"
+      }];
   // This video ad was viewed more than 50 percent. If this is true, then
   // completed_25_percent_plus and completed_0_percent_plus must be true.
-  bool completed_50_percent_plus = 3;
+  bool completed_50_percent_plus = 3
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Completed 50%+"
+      }];
   // This video ad was viewed more than 75 percent. If this is true, then
   // completed_50_percent_plus, completed_25_percent_plus and
   // completed_0_percent_plus must be true.
-  bool completed_75_percent_plus = 4;
+  bool completed_75_percent_plus = 4
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Completed 75%+"
+      }];
   // This video ad was viewed 100 percent. If this is true, then
   // completed_75_percent_plus, completed_50_percent_plus,
   // completed_25_percent_plus and completed_0_percent_plus must be true.
-  bool completed_100_percent = 5;
+  bool completed_100_percent = 5
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Completed 100%"
+      }];
 
   // More than 0% of the ad was displayed in the browser for more than
   // 0 seconds.
-  bool viewable_0_percent_plus = 6;
+  bool viewable_0_percent_plus = 6
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 0%+"
+      }];
   // More than 50% of the ad was displayed in the browser for at least
   // 2 continuous seconds.
   // AKA Old MRC Viewability standard
-  bool viewable_50_percent_plus = 7;
+  bool viewable_50_percent_plus = 7
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 50%+"
+      }];
   // 100% of the ad was displayed in the browser for at least
   // 2 continuous seconds.
   // AKA New MRC Viewability standard
-  bool viewable_100_percent = 8;
+  bool viewable_100_percent = 8
+      [(.wfa.measurement.api.v2alpha.template_field) = {
+        display_name: "Viewable 100%"
+      }];
 }

--- a/src/main/proto/eventtemplates/video_template.proto
+++ b/src/main/proto/eventtemplates/video_template.proto
@@ -23,7 +23,7 @@ option java_multiple_files = true;
 
 message Video {
   option (.wfa.measurement.api.v2alpha.event_template) = {
-    name: "Video"
+    name: "video"
     display_name: "Video Ad"
     description: "An Event Template for video ad events."
   };


### PR DESCRIPTION
Templates shouldn't have message fields unless the messages are protobuf well-known types. All template fields should either be a scalar type or a well-known protobuf type (https://protobuf.dev/reference/protobuf/google.protobuf/)