### PR TITLE
Alpha 1.0/1.5.0 synthetic data 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/alpha_1_0/*.csv.gz filter=lfs diff=lfs merge=lfs -text

--- a/data/alpha_1_0/EDP_DIGITAL1_fake_data.csv.gz
+++ b/data/alpha_1_0/EDP_DIGITAL1_fake_data.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31555a4fd9a8092d511be6797b1574b7c0c1629fedf29fa60757afa911ed7060
+size 54463936

--- a/data/alpha_1_0/EDP_DIGITAL2_fake_data.csv.gz
+++ b/data/alpha_1_0/EDP_DIGITAL2_fake_data.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fd9c24918d36b74efa72f0ca3a2cb26561c09bab474bbf22d8a23790d17a667
+size 158396563

--- a/data/alpha_1_0/EDP_TV_fake_data.csv.gz
+++ b/data/alpha_1_0/EDP_TV_fake_data.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4eeeafcc0589e941dda289a43038ca18321aa80096f772c4cebbf4fbf030092
+size 285594436

--- a/data/alpha_1_0/README.md
+++ b/data/alpha_1_0/README.md
@@ -1,0 +1,15 @@
+# The Alpha 1.0 synthetic dataset
+
+Labelled impressions for 3 EDPs (2 Digital + 1 TV) ranging from 01/09/2022 to 30/11/2022
+
+### Key dataset properties
+* All impressions have available filters as defined on the Origin Pilot Event Templates document
+* Video Completion Status (0%+, 25%+, 50%+, 75%+, 100%)
+* Viewability (0%+, 50%+, 100%)
+
+
+
+| | EDP1 - Digital | EDP2 - Digital | EDP3 - TV |
+|-|-|-|-|
+| Impressions |  9,037,486 | 26,975,152 | 54,166,445 |
+| Reach | 3,162,516 | 9,472,377 | 18,967,104 |


### PR DESCRIPTION
Adding Alpha 1.0 synthetic data (that we'll also use for 1.5.0) to the repository.

Note: data files are over 100MB, so I've enabled and committed binaries in [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github).